### PR TITLE
[1.x] Add support for user UUIDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - [Publish](#publish)
 - [Usage](#usage)
     - [Configuration](#configuration)
+      - [User Configuration](#user-configuration) 
     - [Laravel Cart Facade](#laravel-cart-facade)
       - [Driver](#driver)
       - [Support Drivers](#support-drivers)
@@ -92,6 +93,23 @@ After publishing, run the `php artisan migrate` command.
 ### Configuration
 
 You can config the `Laravel Cart` with `laravel-cart.php` config that exists in `config` folder.
+
+<a name="user-configuration"></a>
+#### User Configuration
+
+If you are using `uuid` or `ulid`, you can change `foreign_key_type` to your correct foreign key type:
+
+```php
+'users' => [
+    ...
+
+    /*
+     * Specify the type of foreign key being used (e.g., 'id', 'uuid', 'ulid').
+     * For non-standard IDs, make sure to add the relevant traits to your models.
+     */
+    'foreign_key_type' => 'id', // Options: uuid, ulid, id
+],
+```
 
 <a name="laravel-cart-facade"></a>
 ### Laravel Cart Facade

--- a/config/laravel-cart.php
+++ b/config/laravel-cart.php
@@ -16,6 +16,12 @@ return [
          * The user foreign key.
          */
         'foreign_id' => 'user_id',
+
+        /*
+         * Specify the type of foreign key being used (e.g., 'id', 'uuid', 'ulid').
+         * For non-standard IDs, make sure to add the relevant traits to your models.
+         */
+        'foreign_key_type' => 'id', // Options: uuid, ulid, id
     ],
 
     /*

--- a/database/migrations/2024_05_31_102710_create_carts_table.php
+++ b/database/migrations/2024_05_31_102710_create_carts_table.php
@@ -19,8 +19,6 @@ return new class extends Migration
         Schema::create($table, function (Blueprint $table) use ($userTableName, $userForeignName, $type) {
             $table->id();
 
-            $table->foreignId($userForeignName)->constrained($userTableName)->cascadeOnDelete();
-
             if ($type === 'ulid') {
                 $table->foreignUlid($userForeignName)
                     ->constrained($userTableName)

--- a/database/migrations/2024_05_31_102710_create_carts_table.php
+++ b/database/migrations/2024_05_31_102710_create_carts_table.php
@@ -22,15 +22,15 @@ return new class extends Migration
             $table->foreignId($userForeignName)->constrained($userTableName)->cascadeOnDelete();
 
             if ($type === 'ulid') {
-                $table->foreignUlid($$userForeignName)
+                $table->foreignUlid($userForeignName)
                     ->constrained($userTableName)
                     ->cascadeOnDelete();
             } else if ($type === 'uuid') {
-                $table->foreignUuid($$userForeignName)
+                $table->foreignUuid($userForeignName)
                     ->constrained($userTableName)
                     ->cascadeOnDelete();
             } else {
-                $table->foreignId($$userForeignName)
+                $table->foreignId($userForeignName)
                     ->constrained($userTableName)
                     ->cascadeOnDelete();
             }

--- a/database/migrations/2024_05_31_102710_create_carts_table.php
+++ b/database/migrations/2024_05_31_102710_create_carts_table.php
@@ -13,12 +13,27 @@ return new class extends Migration
     {
         $userTableName = config('laravel-cart.users.table', 'users');
         $userForeignName = config('laravel-cart.users.foreign_id', 'user_id');
+        $type = config('laravel-cart.users.foreign_key_type', 'id');
         $table = config('laravel-cart.carts.table', 'carts');
 
-        Schema::create($table, function (Blueprint $table) use ($userTableName, $userForeignName) {
+        Schema::create($table, function (Blueprint $table) use ($userTableName, $userForeignName, $type) {
             $table->id();
 
             $table->foreignId($userForeignName)->constrained($userTableName)->cascadeOnDelete();
+
+            if ($type === 'ulid') {
+                $table->foreignUlid($$userForeignName)
+                    ->constrained($userTableName)
+                    ->cascadeOnDelete();
+            } else if ($type === 'uuid') {
+                $table->foreignUuid($$userForeignName)
+                    ->constrained($userTableName)
+                    ->cascadeOnDelete();
+            } else {
+                $table->foreignId($$userForeignName)
+                    ->constrained($userTableName)
+                    ->cascadeOnDelete();
+            }
 
             $table->timestamps();
         });

--- a/src/Drivers/Driver.php
+++ b/src/Drivers/Driver.php
@@ -6,15 +6,15 @@ use Illuminate\Database\Eloquent\Model;
 
 interface Driver
 {
-    public function storeItem(Model|array $item, ?int $userId = null): Driver;
+    public function storeItem(Model|array $item, ?string $userId = null): Driver;
 
-    public function storeItems(array $items, ?int $userId = null): Driver;
+    public function storeItems(array $items, ?string $userId = null): Driver;
 
-    public function increaseQuantity(Model $item, int $quantity = 1, ?int $userId = null): Driver;
+    public function increaseQuantity(Model $item, int $quantity = 1, ?string $userId = null): Driver;
 
-    public function decreaseQuantity(Model $item, int $quantity = 1, ?int $userId = null): Driver;
+    public function decreaseQuantity(Model $item, int $quantity = 1, ?string $userId = null): Driver;
 
-    public function removeItem(Model $item, ?int $userId = null): Driver;
+    public function removeItem(Model $item, ?string $userId = null): Driver;
 
-    public function emptyCart(?int $userId = null): Driver;
+    public function emptyCart(?string $userId = null): Driver;
 }

--- a/src/Drivers/LaravelCartDatabase.php
+++ b/src/Drivers/LaravelCartDatabase.php
@@ -11,7 +11,7 @@ class LaravelCartDatabase implements Driver
     /**
      * Store item in cart.
      */
-    public function storeItem(Model|array $item, ?int $userId = null): static
+    public function storeItem(Model|array $item, ?string $userId = null): static
     {
         $cart = Cart::query()->firstOrCreate(['user_id' => $this->resolveUserId($userId)]);
         $cart->storeItem($item);
@@ -22,7 +22,7 @@ class LaravelCartDatabase implements Driver
     /**
      * Store multiple items in cart.
      */
-    public function storeItems(array $items, ?int $userId = null): static
+    public function storeItems(array $items, ?string $userId = null): static
     {
         $cart = Cart::query()->firstOrCreate(['user_id' => $this->resolveUserId($userId)]);
         $cart->storeItems($items);
@@ -33,7 +33,7 @@ class LaravelCartDatabase implements Driver
     /**
      * Increase the quantity of the item.
      */
-    public function increaseQuantity(Model $item, int $quantity = 1, ?int $userId = null): static
+    public function increaseQuantity(Model $item, int $quantity = 1, ?string $userId = null): static
     {
         $cart = Cart::query()->firstOrCreate(['user_id' => $this->resolveUserId($userId)]);
         $item = $cart->items()->firstWhere('itemable_id', $item->getKey());
@@ -50,7 +50,7 @@ class LaravelCartDatabase implements Driver
     /**
      * Decrease the quantity of the item.
      */
-    public function decreaseQuantity(Model $item, int $quantity = 1, ?int $userId = null): static
+    public function decreaseQuantity(Model $item, int $quantity = 1, ?string $userId = null): static
     {
         $cart = Cart::query()->firstOrCreate(['user_id' => $this->resolveUserId($userId)]);
         $item = $cart->items()->firstWhere('itemable_id', $item->getKey());
@@ -67,7 +67,7 @@ class LaravelCartDatabase implements Driver
     /**
      * Remove a single item from the cart
      */
-    public function removeItem(Model $item, ?int $userId = null): static
+    public function removeItem(Model $item, ?string $userId = null): static
     {
         $cart = Cart::query()->firstOrCreate(['user_id' => $this->resolveUserId($userId)]);
         $itemToDelete = $cart->items()->find($item->getKey());
@@ -79,7 +79,7 @@ class LaravelCartDatabase implements Driver
     /**
      * Remove every item from the cart
      */
-    public function emptyCart(?int $userId = null): static
+    public function emptyCart(?string $userId = null): static
     {
         $cart = Cart::query()->firstOrCreate(['user_id' => $this->resolveUserId($userId)]);
         $cart->emptyCart();
@@ -90,7 +90,7 @@ class LaravelCartDatabase implements Driver
     /**
      * Get option for item.
      */
-    public function getOption(string $option, ?int $itemId = null, ?int $userId = null): mixed
+    public function getOption(string $option, ?int $itemId = null, ?string $userId = null): mixed
     {
         $cart = Cart::query()->firstOrCreate(['user_id' => $this->resolveUserId($userId)]);
         $items = $cart->items()->when(! is_null($itemId), function (Builder $builder) use ($itemId) {
@@ -103,7 +103,7 @@ class LaravelCartDatabase implements Driver
     /**
      * Get all options of one item.
      */
-    public function getOptions(?int $itemId = null, ?int $userId = null): mixed
+    public function getOptions(?int $itemId = null, ?string $userId = null): mixed
     {
         $cart = Cart::query()->firstOrCreate(['user_id' => $this->resolveUserId($userId)]);
         $items = $cart->items()->when(! is_null($itemId), function (Builder $builder) use ($itemId) {
@@ -116,7 +116,7 @@ class LaravelCartDatabase implements Driver
     /**
      * Set option for item.
      */
-    public function setOption(string $key, mixed $value, ?int $itemId = null, ?int $userId = null): static
+    public function setOption(string $key, mixed $value, ?int $itemId = null, ?string $userId = null): static
     {
         $cart = Cart::query()->firstOrCreate(['user_id' => $this->resolveUserId($userId)]);
         $items = $cart->items()->when(! is_null($itemId), function (Builder $builder) use ($itemId) {
@@ -131,7 +131,7 @@ class LaravelCartDatabase implements Driver
     /**
      * Get option for item.
      */
-    public function addOption(string $key, mixed $value, ?int $itemId = null, ?int $userId = null): static
+    public function addOption(string $key, mixed $value, ?int $itemId = null, ?string $userId = null): static
     {
         $cart = Cart::query()->firstOrCreate(['user_id' => $this->resolveUserId($userId)]);
         $items = $cart->items()->when(! is_null($itemId), function (Builder $builder) use ($itemId) {
@@ -146,7 +146,7 @@ class LaravelCartDatabase implements Driver
     /**
      * Resolve the user ID, defaulting to the authenticated user.
      */
-    protected function resolveUserId(?int $userId): int
+    protected function resolveUserId(?string $userId): string
     {
         return $userId ?? auth()->id();
     }

--- a/src/Drivers/LaravelCartSession.php
+++ b/src/Drivers/LaravelCartSession.php
@@ -12,7 +12,7 @@ class LaravelCartSession implements Driver
     /**
      * Store item in cart.
      */
-    public function storeItem(Model|array $item, ?int $userId = null): static
+    public function storeItem(Model|array $item, ?string $userId = null): static
     {
         $userId = $this->resolveUserId($userId);
         $cart = $this->getCart($userId);
@@ -43,7 +43,7 @@ class LaravelCartSession implements Driver
     /**
      * Store multiple items in cart.
      */
-    public function storeItems(array $items, ?int $userId = null): static
+    public function storeItems(array $items, ?string $userId = null): static
     {
         foreach ($items as $item) {
             $this->storeItem($item, $userId);
@@ -55,7 +55,7 @@ class LaravelCartSession implements Driver
     /**
      * Increase the quantity of the item.
      */
-    public function increaseQuantity(Model $item, int $quantity = 1, ?int $userId = null): static
+    public function increaseQuantity(Model $item, int $quantity = 1, ?string $userId = null): static
     {
         $userId = $this->resolveUserId($userId);
         $cart = $this->getCart($userId);
@@ -75,7 +75,7 @@ class LaravelCartSession implements Driver
     /**
      * Decrease the quantity of the item.
      */
-    public function decreaseQuantity(Model $item, int $quantity = 1, ?int $userId = null): static
+    public function decreaseQuantity(Model $item, int $quantity = 1, ?string $userId = null): static
     {
         $userId = $this->resolveUserId($userId);
         $cart = $this->getCart($userId);
@@ -95,7 +95,7 @@ class LaravelCartSession implements Driver
     /**
      * Remove a single item from the cart.
      */
-    public function removeItem(Model $item, ?int $userId = null): static
+    public function removeItem(Model $item, ?string $userId = null): static
     {
         $userId = $this->resolveUserId($userId);
         $cart = $this->getCart($userId);
@@ -109,7 +109,7 @@ class LaravelCartSession implements Driver
     /**
      * Remove every item from the cart.
      */
-    public function emptyCart(?int $userId = null): static
+    public function emptyCart(?string $userId = null): static
     {
         $userId = $this->resolveUserId($userId);
         session([$this->sessionKey($userId) => []]);
@@ -120,7 +120,7 @@ class LaravelCartSession implements Driver
     /**
      * Get the cart from the session.
      */
-    protected function getCart(?int $userId = null): array
+    protected function getCart(?string $userId = null): array
     {
         $userId = $this->resolveUserId($userId);
 
@@ -130,7 +130,7 @@ class LaravelCartSession implements Driver
     /**
      * Resolve the session key for a user.
      */
-    protected function sessionKey(int $userId): string
+    protected function sessionKey(string $userId): string
     {
         return self::SESSION_KEY_PREFIX.$userId;
     }
@@ -138,7 +138,7 @@ class LaravelCartSession implements Driver
     /**
      * Resolve the user ID, defaulting to the authenticated user.
      */
-    protected function resolveUserId(?int $userId): int
+    protected function resolveUserId(?string $userId): string
     {
         return $userId ?? auth()->id();
     }

--- a/src/LaravelCart.php
+++ b/src/LaravelCart.php
@@ -4,16 +4,16 @@ namespace Binafy\LaravelCart;
 
 /**
  * @method static \Binafy\LaravelCart\Drivers\Driver driver(string|null $driver = null)
- * @method static \Binafy\LaravelCart\Drivers\Driver storeItem(\Illuminate\Database\Eloquent\Model|array $item, int|null $userId = null)
+ * @method static \Binafy\LaravelCart\Drivers\Driver storeItem(\Illuminate\Database\Eloquent\Model|array $item, string|null $userId = null)
  * @method static \Binafy\LaravelCart\Drivers\Driver storeItems(array $items)
  * @method static \Binafy\LaravelCart\Drivers\Driver increaseQuantity(\Illuminate\Database\Eloquent\Model $item, int $quantity = 1)
  * @method static \Binafy\LaravelCart\Drivers\Driver decreaseQuantity(\Illuminate\Database\Eloquent\Model $item, int $quantity = 1)
  * @method static \Binafy\LaravelCart\Drivers\Driver removeItem(\Illuminate\Database\Eloquent\Model $item)
  * @method static \Binafy\LaravelCart\Drivers\Driver emptyCart()
- * @method static \Binafy\LaravelCart\Drivers\Driver getOption(string $option, ?int $itemId = null, ?int $userId = null)
- * @method static \Binafy\LaravelCart\Drivers\Driver getOptions(?int $itemId = null, ?int $userId = null)
- * @method static \Binafy\LaravelCart\Drivers\Driver setOption(string $key, mixed $value, ?int $itemId = null, ?int $userId = null)
- * @method static \Binafy\LaravelCart\Drivers\Driver addOption(string $key, mixed $value, ?int $itemId = null, ?int $userId = null)
+ * @method static \Binafy\LaravelCart\Drivers\Driver getOption(string $option, ?int $itemId = null, ?string $userId = null)
+ * @method static \Binafy\LaravelCart\Drivers\Driver getOptions(?int $itemId = null, ?string $userId = null)
+ * @method static \Binafy\LaravelCart\Drivers\Driver setOption(string $key, mixed $value, ?int $itemId = null, ?string $userId = null)
+ * @method static \Binafy\LaravelCart\Drivers\Driver addOption(string $key, mixed $value, ?int $itemId = null, ?string $userId = null)
  * @method static string getDefaultDriver()
  * @method static void setDefaultDriver(string $name)
  *

--- a/src/Models/Cart.php
+++ b/src/Models/Cart.php
@@ -14,11 +14,11 @@ use Illuminate\Database\Eloquent\Model;
 class Cart extends Model
 {
     /**
-     * Fillable columns.
+     * Guarded columns.
      *
-     * @var string[]
+     * @var array
      */
-    protected $fillable = ['user_id'];
+    protected $guarded = ['id'];
 
     /**
      * The relations to eager load on every query.

--- a/src/Models/Cart.php
+++ b/src/Models/Cart.php
@@ -56,7 +56,7 @@ class Cart extends Model
         Builder $query,
         Model $item,
         int $quantity = 1,
-        ?int $userId = null
+        ?string $userId = null
     ): Builder {
         if (is_null($userId)) {
             $userId = auth()->id();


### PR DESCRIPTION
This simply changes all occurrences of `int $userId` in method params to now be `string $userId`. This adds support for user UUIDs while maintaining support for regular ids.

fixes #41 